### PR TITLE
ip lists: ensure file end with a  \n

### DIFF
--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -109,13 +109,14 @@ define ipset::set (
     # content
     case $set {
       IPSet::Set::Array: { # lint:ignore:unquoted_string_in_case
+        $new_set = join($set, "\n")
         # create file with ipset, one record per line
         file { "${config_path}/${title}.set":
           ensure  => file,
           owner   => 'root',
           group   => 'root',
           mode    => '0640',
-          content => inline_template('<%= (@set.map { |i| i.to_s }).join("\n") %>'),
+          content => "${new_set}\n",
         }
       }
       IPSet::Set::Puppet_URL: { # lint:ignore:unquoted_string_in_case

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -44,7 +44,7 @@ simple_test_cases = [
   [
     'array',
     ['10.0.0.1', '192.168.0.1'],
-    { content: "10.0.0.1\n192.168.0.1" }
+    { content: "10.0.0.1\n192.168.0.1\n" }
   ],
   [
     'string',
@@ -64,22 +64,22 @@ simple_test_cases = [
   [
     'array',
     ['10.0.0.1 #Comment 1', '192.168.0.1 #Comment 2'],
-    { content: "10.0.0.1 #Comment 1\n192.168.0.1 #Comment 2" }
+    { content: "10.0.0.1 #Comment 1\n192.168.0.1 #Comment 2\n" }
   ],
   [
     'array',
     ['10.0.0.1,80', '192.168.0.1,443'],
-    { content: "10.0.0.1,80\n192.168.0.1,443" }
+    { content: "10.0.0.1,80\n192.168.0.1,443\n" }
   ],
   [
     'string',
     ["10.0.0.1 #Comment 1\n192.168.0.1 #Comment 2"],
-    { content: "10.0.0.1 #Comment 1\n192.168.0.1 #Comment 2" }
+    { content: "10.0.0.1 #Comment 1\n192.168.0.1 #Comment 2\n" }
   ],
   [
     'string',
     ["10.0.0.1,80\n192.168.0.1,443"],
-    { content: "10.0.0.1,80\n192.168.0.1,443" }
+    { content: "10.0.0.1,80\n192.168.0.1,443\n" }
   ]
 ]
 
@@ -156,7 +156,7 @@ describe 'ipset::set' do
       content: "create custom hash:net family inet hashsize 2048 maxelem 65536\n",
       # rubocop:enable Metrics/LineLength
     )
-    check_file_set_content('custom', content: "10.0.0.0/8\n192.168.0.0/16")
+    check_file_set_content('custom', content: "10.0.0.0/8\n192.168.0.0/16\n")
     check_exec_sync(
       'custom',
       command: "ipset_sync -c '/etc/sysconfig/ipset.d'    -i custom -n",


### PR DESCRIPTION
Without this change, the files will not contain a `\n` after the last
element. This makes the diff ugly if a new entry is added. Also an
editor might add the newline if the file will be opened. Afterwards
puppet removes it again.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
