### PR TITLE
fix typo in ipset.service

### DIFF
--- a/templates/ipset.service.epp
+++ b/templates/ipset.service.epp
@@ -9,7 +9,7 @@ Documentation=https://github.com/voxpupuli/puppet-ipset
 <% if $firewall_service { -%>
 Before=<%= $firewall_service %>
 <% } -%>
-<% if $firewall_service { -%>
+<% if $service_dependency { -%>
 Require=<%= $service_dependency %>
 <% } -%>
 After=network-online.target


### PR DESCRIPTION
A condition was wrong. We want to depend on
systemd-networkd-wait-online.service if systemd-networkd is running.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
