### PR TITLE
dont depend on working network connectivity

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,20 +52,12 @@ class ipset (
   # configure custom unit file
   case $facts['service_provider'] {
     'systemd': {
-      # It's quite common that people use systemd-networkd to cofigure their network
-      # that will provide us with systemd-networkd-wait-online.service. If it's enabled,
-      # the ipset service should wait for it to become online.
-      $service_dependency = fact('systemd_internal_services."systemd-networkd-wait-online.service"') ? {
-        undef => undef,
-        default => 'systemd-networkd-wait-online.service'
-      }
       systemd::unit_file{"${service}.service":
         enable    => $enable,
         active    => $service_ensure,
         content   => epp("${module_name}/ipset.service.epp",{
-          'firewall_service'   => $firewall_service,
-          'config_path'        => $config_path,
-          'service_dependency' => $service_dependency,
+          'firewall_service' => $firewall_service,
+          'config_path'      => $config_path,
           }),
         subscribe => [File['/usr/local/bin/ipset_init'], File['/usr/local/bin/ipset_sync']],
       }

--- a/templates/ipset.service.epp
+++ b/templates/ipset.service.epp
@@ -1,6 +1,5 @@
 <%- | Optional[String[1]] $firewall_service,
   Stdlib::Absolutepath $config_path,
-  Optional[String[1]] $service_dependency,
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
 [Unit]
@@ -8,9 +7,6 @@ Description=define and fill-in ipsets
 Documentation=https://github.com/voxpupuli/puppet-ipset
 <% if $firewall_service { -%>
 Before=<%= $firewall_service %>
-<% } -%>
-<% if $service_dependency { -%>
-Require=<%= $service_dependency %>
 <% } -%>
 After=network-online.target
 Wants=network-online.target


### PR DESCRIPTION
In the past, ipset had a dependency to a working network connection
(with available ip addresses and routes and stuff like this), if
systemd-networkd was used. This doesn't make any sense and might even
introduce dependency cycles. We can start as soon as the kernel is ready
to accept calls from ipset. And we need to start before iptables tries
to use us. This will be fixed in a seperate commit.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
