### PR TITLE
fix systemd unit dependencies

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,20 +52,12 @@ class ipset (
   # configure custom unit file
   case $facts['service_provider'] {
     'systemd': {
-      # It's quite common that people use systemd-networkd to cofigure their network
-      # that will provide us with systemd-networkd-wait-online.service. If it's enabled,
-      # the ipset service should wait for it to become online.
-      $service_dependency = fact('systemd_internal_services."systemd-networkd-wait-online.service"') ? {
-        undef => undef,
-        default => 'systemd-networkd-wait-online.service'
-      }
       systemd::unit_file{"${service}.service":
         enable    => $enable,
         active    => $service_ensure,
         content   => epp("${module_name}/ipset.service.epp",{
-          'firewall_service'   => $firewall_service,
-          'config_path'        => $config_path,
-          'service_dependency' => $service_dependency,
+          'firewall_service' => $firewall_service,
+          'config_path'      => $config_path,
           }),
         subscribe => [File['/usr/local/bin/ipset_init'], File['/usr/local/bin/ipset_sync']],
       }

--- a/templates/ipset.service.epp
+++ b/templates/ipset.service.epp
@@ -1,6 +1,5 @@
 <%- | Optional[String[1]] $firewall_service,
   Stdlib::Absolutepath $config_path,
-  Optional[String[1]] $service_dependency,
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
 [Unit]
@@ -8,9 +7,6 @@ Description=define and fill-in ipsets
 Documentation=https://github.com/voxpupuli/puppet-ipset
 <% if $firewall_service { -%>
 Before=<%= $firewall_service %>
-<% } -%>
-<% if $service_dependency { -%>
-Require=<%= $service_dependency %>
 <% } -%>
 After=network-online.target
 Wants=network-online.target

--- a/templates/ipset.service.epp
+++ b/templates/ipset.service.epp
@@ -8,9 +8,8 @@ Documentation=https://github.com/voxpupuli/puppet-ipset
 <% if $firewall_service { -%>
 Before=<%= $firewall_service %>
 <% } -%>
-After=network-online.target
-Wants=network-online.target
-
+Before=network-pre.target iptables.service ip6tables.service
+Wants=network-pre.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This service should start before iptables/ip6tables starts. This is based on https://git.archlinux.org/svntogit/packages.git/tree/trunk/ipset.service?h=packages/ipset It's not required to wait for the whole network stack to come available to add ipsets.