### PR TITLE
systemd unit: switch target from basic to multi-user

### DIFF
--- a/templates/ipset.service.epp
+++ b/templates/ipset.service.epp
@@ -17,4 +17,4 @@ RemainAfterExit=yes
 ExecStart=/usr/local/bin/ipset_init -c "<%= $config_path %>"
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target


### PR DESCRIPTION
The basic target doesn't make any sense, multi-user is totally fine.