### PR TITLE
Ignore hashsize to avoid conflicts on large sets

### DIFF
--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -121,7 +121,10 @@ function ipset_insync_common() {
 
   # compare configured and runtime config
   tf=$(mktemp)
-  diff <(get_ipset_dump ${id} | grep ^${pfx}) <(construct_ipset_dump ${id} | grep ^${pfx}) > ${tf}
+  diff \
+    <(get_ipset_dump ${id} | grep ^${pfx} | sed 's/hashsize [0-9]\+ //g') \
+    <(construct_ipset_dump ${id} | grep ^${pfx} | sed 's/hashsize [0-9]\+ //g') \
+    > ${tf}
   local rv=$?
 
   # show differences, if requested by CLI option


### PR DESCRIPTION
ipset hashsize grows dynamically to accommodate very large sets and
could differ from size used during creation. fixes #26

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
