### PR TITLE
Avoid emptying set file for unmanaged sets

### DIFF
--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -116,26 +116,29 @@ define ipset::set (
           group   => 'root',
           mode    => '0640',
           content => "${new_set}\n",
+          replace => !$ignore_contents,
         }
       }
       IPSet::Set::Puppet_URL: { # lint:ignore:unquoted_string_in_case
         # passed as puppet file
         file { "${config_path}/${title}.set":
-          ensure => file,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0640',
-          source => $set,
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0640',
+          source  => $set,
+          replace => !$ignore_contents,
         }
       }
       IPSet::Set::File_URL: { # lint:ignore:unquoted_string_in_case
         # passed as target node file
         file { "${config_path}/${title}.set":
-          ensure => file,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0640',
-          source => regsubst($set, '^.{7}', ''),
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0640',
+          source  => regsubst($set, '^.{7}', ''),
+          replace => !$ignore_contents,
         }
       }
       String: {
@@ -146,6 +149,7 @@ define ipset::set (
           group   => 'root',
           mode    => '0640',
           content => $set,
+          replace => !$ignore_contents,
         }
       }
       default: {

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -156,7 +156,11 @@ describe 'ipset::set' do
       content: "create custom hash:net family inet hashsize 2048 maxelem 65536\n",
       # rubocop:enable Metrics/LineLength
     )
-    check_file_set_content('custom', content: "10.0.0.0/8\n192.168.0.0/16\n")
+    check_file_set_content(
+      'custom',
+      content: "10.0.0.0/8\n192.168.0.0/16\n",
+      replace: false
+    )
     check_exec_sync(
       'custom',
       command: "ipset_sync -c '/etc/sysconfig/ipset.d'    -i custom -n",
@@ -235,4 +239,38 @@ describe 'ipset::set' do
   end
 
   it { is_expected.not_to compile }
+end
+
+describe 'ipset::unmanaged' do
+  context 'unmanaged' do
+    let :pre_condition do
+      'include ipset'
+    end
+
+    let(:title) { 'unmanaged' }
+    let :params do
+      {
+        ensure: 'present',
+      }
+    end
+
+    let :facts do
+      {
+        os: {
+          family: 'RedHat',
+          release: {
+            major: 7
+          }
+        },
+        systemd: true,
+        service_provider: 'systemd'
+      }
+    end
+
+    it do
+      is_expected.to contain_ipset__set('unmanaged').with(
+        ignore_contents: true
+      )
+    end
+  end
 end


### PR DESCRIPTION
(#39) This change applies the inverse of the ignore_content
variable to the replace parameter on *.set file resources in the
ipset::set class, preventing unmanaged ipsets from having their set
files emptied each puppet run

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Per the `ipset::unmanaged` section in the readme, unmanaged sets won't be kept if the set options are changed, but the set file is still emptied with each puppet run. It does leave the in-memory set in place, but this is less than ideal as in the event of an unexpected reboot the set could remain empty until the set file is next updated.

This change leaves the set file intact in addition to the in-memory ipset for unmanaged sets. This is more inline with my expectation of how an unmanaged set should behave, but I'm curious what you think.

#### This Pull Request (PR) fixes the following issues
#39 
