### PR TITLE
add 'sets' hash to configure 'ipset::set' resource via Hiera

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,9 @@
 # @param config_path
 #   path to the directory for the ipsets
 #
+# @param sets
+#   Hash Hash of 'ipset::set' resources
+#
 class ipset (
   Array[String[1]] $packages,
   String[1] $service,
@@ -29,6 +32,7 @@ class ipset (
   Enum['present', 'absent', 'latest'] $package_ensure,
   Stdlib::Absolutepath $config_path,
   Optional[Pattern[/\.service$/]] $firewall_service = undef,
+  Hash $sets = {},
 ) {
   package { $ipset::packages:
     ensure => $package_ensure,
@@ -85,6 +89,12 @@ class ipset (
     }
     default: {
       fail('The ipset module only supports systemd and RedHat 6 based distributions')
+    }
+  }
+
+  $sets.each |$set, $attributes| {
+    ipset::set { $set:
+      * => $attributes,
     }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -46,6 +46,42 @@ describe 'ipset' do
           it { is_expected.not_to contain_package('ipset-service') }
         end
       end
+
+      context 'with sets attributes' do
+        let :params do
+          {
+            sets: {
+              'basic-set-v4' => {
+                'set'  => "['10.0.0.1', '10.0.0.2', '10.0.0.42']",
+                'type' => 'hash:net'
+              },
+              'basic-set-v6' => {
+                'set'  => "['fc00::1/128', 'fc00::2/128', 'fc00::2/128']",
+                'type' => 'hash:net',
+                'options' => {
+                  'family' => 'inet6'
+                }
+              }
+            }
+          }
+        end
+
+        it do
+          is_expected.to contain_ipset__set('basic-set-v4'). \
+            with(
+              'set'  => "['10.0.0.1', '10.0.0.2', '10.0.0.42']",
+              'type' => 'hash:net'
+            )
+          is_expected.to contain_ipset__set('basic-set-v6').\
+            with(
+              'set'  => "['fc00::1/128', 'fc00::2/128', 'fc00::2/128']",
+              'type' => 'hash:net',
+              'options' => {
+                'family' => 'inet6'
+              }
+            )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add `ipset::sets` parameter to enable configuration of `ipset::set` resources via Hiera.

Like 'puppet-ferm': (e.g.) `ferm::rule` resources via Hiera (https://github.com/voxpupuli/puppet-ferm).