### PR TITLE
use 'content' instead of 'source' to increase performance

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,18 +45,18 @@ class ipset (
 
   # setup the helper scripts
   file { '/usr/local/bin/ipset_sync':
-    ensure => 'file',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0754',
-    source => "puppet:///modules/${module_name}/ipset_sync",
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0754',
+    content => file("${module_name}/ipset_sync"),
   }
   file { '/usr/local/bin/ipset_init':
-    ensure => 'file',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0754',
-    source => "puppet:///modules/${module_name}/ipset_init",
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0754',
+    content => file("${module_name}/ipset_init"),
   }
 
   # configure custom unit file


### PR DESCRIPTION
This pull-request replaces 'source' parameters with 'content' to increase performance of Puppet Servers / decrease load on Puppet Servers.

When serving (a lot of) agents concurrently using 'content' instead of 'source' mitigates 'attempt to read body out of block' errors.

```
Error: /Stage[main]/Ipset/File[/usr/local/bin/ipset_sync]: Could not evaluate: Could not retrieve file metadata for puppet:///modules/ipset/ipset_sync: Request to https://<puppetserver>:8140/puppet/v3/file_metadata/modules/ipset/ipset_sync?links=manage&checksum_type=sha256&source_permissions=ignore&environment=stable failed after 583.136 seconds: attempt to read body out of block
```