### PR TITLE
Override DefaultDependencies on ipset service unit

### DIFF
--- a/templates/ipset.service.epp
+++ b/templates/ipset.service.epp
@@ -5,11 +5,19 @@
 [Unit]
 Description=define and fill-in ipsets
 Documentation=https://github.com/voxpupuli/puppet-ipset
+DefaultDependencies=no
+
 <% if $firewall_service { -%>
 Before=<%= $firewall_service %>
 <% } -%>
 Before=network-pre.target iptables.service ip6tables.service
 Wants=network-pre.target
+
+Conflicts=shutdown.target
+Before=shutdown.target
+
+Wants=systemd-modules-load.service local-fs.target
+After=systemd-modules-load.service local-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
#### Pull Request (PR) description

The current ipset service unit sets `Before=network-pre.target` as it is needed before the network to help ensure that the firewall is up and running before anyone might actually try to connect. It has no setting
for `DefaultDependencies` which means it takes the defaults, one of which is `After=sysinit.target`.

There are some cases where this can cause a dependency cycle with other units that want to start early in the boot process between `networking.service` and `sysinit.target` (for example, cloud-init). This results in one of the offending units being removed and risks startup continuing without ipsets being configured, potentially leaving a firewall open and a host at risk.

The ipset service can safely be run before `sysinit.target` by setting `DefaultDependencies=no` with a couple of additional dependencies to handle some of the other implied settings that are removed as a result.

#### This Pull Request (PR) fixes the following issues

Fixes #63