### PR TITLE
update ipset_sync a bug with ipv6

### DIFF
--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -74,7 +74,7 @@ function construct_ipset_dump() {
         grep -v '^[[:space:]]*$' | \
         sed -re 's@^[[:space:]]*@@' | \
         sed -re 's@[[:space:]]*$@@' | \
-        sed -re 's@/((32)|(128))$@@' | \
+        sed -re 's@((\.[0-9]+)/32|/128)$@\2@' | \
         sed -re 's@[[:space:]]*#.*$@@' | \
         sed -re "s/(.*)/add ${alias} \\1/" | \
         LC_ALL=C sort --unique


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This change it so resolve a problem with ipv6 subnets where the script was removing the /32 on the end of a ipv6 subnet
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
Fixes #65 
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
