### PR TITLE
Update ipset_sync for newer kernels

### DIFF
--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -119,11 +119,11 @@ function ipset_insync_common() {
   local pfx=$2
 
 
-  # compare configured and runtime config
+  # compare configured and runtime config, ignoring hashsize, initval and bucketsize parameters
   tf=$(mktemp)
-  diff \
-    <(get_ipset_dump ${id} | grep ^${pfx} | sed 's/hashsize [0-9]\+ //g') \
-    <(construct_ipset_dump ${id} | grep ^${pfx} | sed 's/hashsize [0-9]\+ //g') \
+  diff -w \
+    <(get_ipset_dump ${id} | grep ^${pfx} | sed -e 's/hashsize [0-9]\+ //g' -e 's/initval 0x[0-9a-f]\+//g' -e 's/bucketsize [0-9]\+ //g') \
+    <(construct_ipset_dump ${id} | grep ^${pfx} | sed -e 's/hashsize [0-9]\+ //g' -e 's/initval 0x[0-9a-f]\+//g' -e 's/bucketsize [0-9]\+ //g') \
     > ${tf}
   local rv=$?
 


### PR DESCRIPTION
Allow ipset_sync script to work with ipset 7.8 and newer, by ignoring the variables when checking the configuration

#### Pull Request (PR) description
This patch makes ipset_sync ignore the `bucketsize` and `initval` parameters. Without it, the module wants to recreate the ipset on every Puppet run. I made diff ignore whitespace as well to reduce sed space tricks required.

I tried to add bucketsize as an actual settable option to the module, which may be nice, but unfortunately stops working on older kernels, and because the module sorts the parameters in $opt_string, it also does not match the order `ipset save` provides.

Diff result on my recent system before this patch:
```
< create vallumd hash:ip family inet maxelem 65536 timeout 3600 bucketsize 12 initval 0xd52632d0
---
> create vallumd hash:ip family inet maxelem 65536 timeout 3600
```