### PR TITLE
Adding dependency on debian iptables service.

### DIFF
--- a/templates/ipset.service.epp
+++ b/templates/ipset.service.epp
@@ -8,7 +8,7 @@ Documentation=https://github.com/voxpupuli/puppet-ipset
 <% if $firewall_service { -%>
 Before=<%= $firewall_service %>
 <% } -%>
-Before=network-pre.target iptables.service ip6tables.service
+Before=network-pre.target iptables.service ip6tables.service netfilter-persistent.service
 Wants=network-pre.target
 
 [Service]


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds a *Before* declaration on `netfilter-persistent.service` which is the service in Debian and Ubuntu that restores the iptables rules.

#### This Pull Request (PR) fixes the following issues

This PR prevents `netfilter-persistent.service` from failing on non-existent ipset.