### PR TITLE
Support for comments and more types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -364,6 +364,6 @@ type to allow all different hash setups for ipsets
 Alias of
 
 ```puppet
-Enum['hash:ip', 'hash:ip,port', 'hash:ip,port,ip', 'hash:ip,port,net', 'hash:ip,mark', 'hash:net', 'hash:net,net', 'hash:net,iface', 'hash:net,port', 'hash:net,port,net', 'hash:mac']
+Enum['bitmap:ip','bitmap:ip,mac','bitmap:port','hash:ip','hash:mac','hash:ip,mac','hash:net','hash:net,net','hash:ip,port','hash:net,port','hash:ip,port,ip','hash:ip,port,net','hash:ip,mark','hash:net,port,net','hash:net,iface','list:set']
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -310,6 +310,8 @@ Struct[{
     Optional[maxelem]  => Integer[128],
     Optional[netmask]  => IP::Address,
     Optional[timeout]  => Integer[1],
+    Optional[range]    => String,
+    Optional[comment]  => String,
 }]
 ```
 

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -82,10 +82,17 @@ define ipset::set (
 
   $config_path = $ipset::config_path
 
-  $default_options = {
-    'family'   => 'inet',
-    'hashsize' => '1024',
-    'maxelem'  => '65536',
+  case $type {
+    default: {
+      $default_options = {}
+    }
+    'hash:ip': {
+      $default_options = {
+        'family'   => 'inet',
+        'hashsize' => '1024',
+        'maxelem'  => '65536',
+      }
+    }
   }
 
   $actual_options = merge($default_options, $options)

--- a/types/options.pp
+++ b/types/options.pp
@@ -9,4 +9,5 @@ type IPSet::Options = Struct[{
     Optional[maxelem]  => Integer[128],
     Optional[netmask]  => IP::Address,
     Optional[timeout]  => Integer[1],
+    Optional[range]    => String,
 }]

--- a/types/options.pp
+++ b/types/options.pp
@@ -10,4 +10,5 @@ type IPSet::Options = Struct[{
     Optional[netmask]  => IP::Address,
     Optional[timeout]  => Integer[1],
     Optional[range]    => String,
+    Optional[comment]  => String,
 }]

--- a/types/set/array.pp
+++ b/types/set/array.pp
@@ -1,4 +1,4 @@
 #
 # @summary type to allow an array of ip addresses
 #
-type IPSet::Set::Array = Array[String]
+type IPSet::Set::Array = Variant[Array[String], Array[Integer]]

--- a/types/settype.pp
+++ b/types/settype.pp
@@ -6,5 +6,4 @@ type IPSet::Settype = Variant[
   IPSet::Set::Puppet_URL,
   IPSet::Set::File_URL,
   String,
-  Integer,
 ]

--- a/types/settype.pp
+++ b/types/settype.pp
@@ -6,4 +6,5 @@ type IPSet::Settype = Variant[
   IPSet::Set::Puppet_URL,
   IPSet::Set::File_URL,
   String,
+  Integer,
 ]

--- a/types/type.pp
+++ b/types/type.pp
@@ -4,15 +4,20 @@
 # @see http://ipset.netfilter.org/ipset.man.html#lbAW documentation for all different hash options
 #
 type IPSet::Type = Enum[
+  'bitmap:ip',
+  'bitmap:ip,mac',
+  'bitmap:port',
   'hash:ip',
+  'hash:mac',
+  'hash:ip,mac',
+  'hash:net',
+  'hash:net,net',
   'hash:ip,port',
+  'hash:net,port',
   'hash:ip,port,ip',
   'hash:ip,port,net',
   'hash:ip,mark',
-  'hash:net',
-  'hash:net,net',
-  'hash:net,iface',
-  'hash:net,port',
   'hash:net,port,net',
-  'hash:mac',
+  'hash:net,iface',
+  'list:set',
 ]


### PR DESCRIPTION
#### Pull Request (PR) description
Add support for comments (#5) and the types from [the man page](http://ipset.netfilter.org/ipset.man.html#lbAW).

`counters skbinfo markmask` options are not implemented, they are boolean options. If anyone has any advice on how to implement that cleanly ...

example with using hiera data:
```yaml
data::from::hiera::ports:
  - 5005
  - 5006
  - 5007
  - 5008
  - 5009
  - 5010
  - 5023
  - 5027
  - 5028
  - 5031
```

```puppet
  ipset::set { 'port-server1':
    set     => lookup('data::from::hiera::ports'),
    type    => 'bitmap:port',
    options => {
      range => '5000-6000',
    },
  }
```

If you want to limit to udp:
```puppet
  ipset::set { 'port-server2':
    set     => lookup('data::from::hiera::ports').map |$value| { "udp:${value}" },
    type    => 'bitmap:port',
    options => {
      range => '5000-6000',
    },
  }
```

This was primarily implemented to be able to create non consecutive port lists as `iptables` only support a maximum of 15 ports with the `--multiports` and the `XT_MULTI_PORTS` compile setting [source](https://serverfault.com/questions/733598/iptables-max-number-of-ports-you-can-specify-with-dport-that-is-not-continous#733607)


