### PR TITLE
Add Debian 11 and Ubuntu 20.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,13 +21,15 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {


### PR DESCRIPTION
Add Debian 11 and Ubuntu 20.04 in the supported OS as the documentation say it's working.