### PR TITLE
make the exec depend on the file it is execing

### DIFF
--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -171,7 +171,7 @@ define ipset::set (
       command     => "ipset_sync -c '${config_path}'    -i ${title}${ignore_contents_opt}",
       # only when difference with in-kernel set is detected
       unless      => "ipset_sync -c '${config_path}' -d -i ${title}${ignore_contents_opt}",
-      require     => Package['ipset'],
+      require     => [Package['ipset'], File['/usr/local/bin/ipset_sync']],
       refreshonly => true,
     }
 

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -34,7 +34,7 @@ def check_exec_sync(name, attributes)
     expect(subject).to contain_exec("sync_ipset_#{name}").
       with({
         path: ['/sbin', '/usr/sbin', '/bin', '/usr/bin', '/usr/local/bin', '/usr/local/sbin'],
-        require: 'Package[ipset]'
+        require: ['Package[ipset]', 'File[/usr/local/bin/ipset_sync]']
       }.merge(attributes)).
       that_subscribes_to("File[/etc/sysconfig/ipset.d/#{name}.set]")
   end


### PR DESCRIPTION
#### Pull Request (PR) description
Fix ordering issue where the Exec runs before the sync script is in place.
```
Error: /Stage[main]/Role::Sdev_docker/Ipset::Set[test]/Exec[sync_ipset_test]: Could not evaluate: Could not find command 'ipset_sync'
```

#### This Pull Request (PR) fixes the following issues
Fixes #35

