### PR TITLE
IP::Address type is no longer supported, switch to Stdlib variant

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -308,7 +308,7 @@ Struct[{
     Optional[family]   => Enum['inet', 'inet6'],
     Optional[hashsize] => Integer[128],
     Optional[maxelem]  => Integer[128],
-    Optional[netmask]  => IP::Address,
+    Optional[netmask]  => Stdlib::IP::Address,
     Optional[timeout]  => Integer[1],
 }]
 ```

--- a/types/options.pp
+++ b/types/options.pp
@@ -7,6 +7,6 @@ type IPSet::Options = Struct[{
     Optional[family]   => Enum['inet', 'inet6'],
     Optional[hashsize] => Integer[128],
     Optional[maxelem]  => Integer[128],
-    Optional[netmask]  => IP::Address,
+    Optional[netmask]  => Stdlib::IP::Address,
     Optional[timeout]  => Integer[1],
 }]


### PR DESCRIPTION
The IP::Address type is no longer supported..
See puppet error
`Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Ipset::Unmanaged[some-ipset]: parameter 'options' references an unresolved type 'IP::Address'`

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The IP::Address type is no longer supported..

#### This Pull Request (PR) fixes the following issues
`Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Ipset::Unmanaged[some-ipset]: parameter 'options' references an unresolved type 'IP::Address'`
