### PR TITLE
Update set.pp, merge deprecation fixed

### DIFF
--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -88,7 +88,7 @@ define ipset::set (
     'maxelem'  => '65536',
   }
 
-  $actual_options = merge($default_options, $options)
+  $actual_options = stdlib::merge($default_options, $options)
 
   if $ensure == 'present' {
     # assert "present" target

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -88,7 +88,7 @@ define ipset::set (
     'maxelem'  => '65536',
   }
 
-  $actual_options = stdlib::merge($default_options, $options)
+  $actual_options = $default_options + $options
 
   if $ensure == 'present' {
     # assert "present" target

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.1.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppet/systemd",


### PR DESCRIPTION
#### Pull Request (PR) description
Fix for annoying warning. Currently merge is part of stdlib

#### This Pull Request (PR) fixes the following issues
```
Warning: This function is deprecated, please use stdlib::merge instead. at ["/etc/puppetlabs/code/environments/production/modules/ipset/manifests/set.pp", 91]:
   (location: /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:35:in `deprecation')
```