### PR TITLE
Revert "Minimum version of stdlib is 9.0.0"

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 9.0.0 < 10.0.0"
+      "version_requirement": ">= 6.1.0 < 10.0.0"
     },
     {
       "name": "puppet/systemd",


### PR DESCRIPTION
This reverts commit a99c5e118c270b1d96a2c6d1b72b56820b9b7fca.

stdlib minimum was raised without it being necessary in https://github.com/voxpupuli/puppet-ipset/pull/105