### PR TITLE
puppet/systemd: Allow 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 2.6.0 < 9.0.0"
+      "version_requirement": ">= 2.6.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION

#### Pull Request (PR) description
Update version requirement for puppet/systemd

#### This Pull Request (PR) fixes the following issues
```
# puppet module install puppet-ipset --version 5.0.0 Notice: Preparing to install into /etc/puppet/code/environments/production/modules ... Notice: Downloading from https://forgeapi.puppet.com ... Error: Could not install module 'puppet-ipset' (v5.0.0)
  The requested version cannot satisfy one or more of the following installed modules:
    puppet-systemd, installed: 9.3.0, expected: >= 2.6.0 < 9.0.0

  Use `puppet module install 'puppet-ipset' --ignore-dependencies` to install only this module


```