### PR TITLE
fix: catch ipset sync failure

### DIFF
--- a/files/ipset_init
+++ b/files/ipset_init
@@ -57,5 +57,14 @@ for item in $(find "${cfg}" -mindepth 1 -maxdepth 1 -type f -and \( -name '*.set
   fi
 
   # sync
-  ${scd}/ipset_sync -c "${cfg}" -i ${item}
+  ${scd}/ipset_sync -c "${cfg}" -i "${item}"
+  result=$?
+  if [ ${result} -ne 0 ]; then
+     echo "Processing ipset ${item} failed with return code ${result}"
+     has_failure=1
+  fi
 done
+
+if [[ "${has_failure}" -eq 1 ]]; then
+    exit 1;
+fi


### PR DESCRIPTION
#### Pull Request (PR) description
Change ipset_init exit code to 1 if at least one ipset_sync failed,

This will allow to properly catch errors.

#### This Pull Request (PR) fixes the following issues

Fixes #132


