### PR TITLE
Added show_diff flag to prevent screen/logging floods for managed ipsets which change frequently

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -190,6 +190,7 @@ The following parameters are available in the `ipset::set` defined type:
 * [`options`](#-ipset--set--options)
 * [`ignore_contents`](#-ipset--set--ignore_contents)
 * [`keep_in_sync`](#-ipset--set--keep_in_sync)
+* [`silent`](#-ipset--set--silent)
 
 ##### <a name="-ipset--set--set"></a>`set`
 
@@ -238,6 +239,16 @@ If ``true``, Puppet will update the IP set in the kernel
 memory. If ``false``, it will only update the IP sets on the filesystem.
 
 Default value: `true`
+
+##### <a name="-ipset--set--silent"></a>`silent`
+
+Data type: `Boolean`
+
+If ``true``, Puppet will not show and log the changes (show_diff) of the new and 
+previous ipset. Usefull for reducing the size of your Puppet logs. If ``false``, 
+it will show and log the difference between sets.
+
+Default value: `false`
 
 ### <a name="ipset--unmanaged"></a>`ipset::unmanaged`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -190,7 +190,7 @@ The following parameters are available in the `ipset::set` defined type:
 * [`options`](#-ipset--set--options)
 * [`ignore_contents`](#-ipset--set--ignore_contents)
 * [`keep_in_sync`](#-ipset--set--keep_in_sync)
-* [`silent`](#-ipset--set--silent)
+* [`show_diff`](#-ipset--set--show_diff)
 
 ##### <a name="-ipset--set--set"></a>`set`
 
@@ -240,13 +240,12 @@ memory. If ``false``, it will only update the IP sets on the filesystem.
 
 Default value: `true`
 
-##### <a name="-ipset--set--silent"></a>`silent`
+##### <a name="-ipset--set--show_diff"></a>`show_diff`
 
 Data type: `Boolean`
 
-If ``true``, Puppet will not show and log the changes (show_diff) of the new and 
-previous ipset. Usefull for reducing the size of your Puppet logs. If ``false``, 
-it will show and log the difference between sets.
+show_diff If ``true``, no diff content is being shown or logged. 
+Useful for larget sets with lot of changes. Default: false
 
 Default value: `false`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -188,9 +188,9 @@ The following parameters are available in the `ipset::set` defined type:
 * [`ensure`](#-ipset--set--ensure)
 * [`type`](#-ipset--set--type)
 * [`options`](#-ipset--set--options)
+* [`show_diff`](#-ipset--set--show_diff)
 * [`ignore_contents`](#-ipset--set--ignore_contents)
 * [`keep_in_sync`](#-ipset--set--keep_in_sync)
-* [`show_diff`](#-ipset--set--show_diff)
 
 ##### <a name="-ipset--set--set"></a>`set`
 
@@ -222,6 +222,15 @@ IP set options.
 
 Default value: `{}`
 
+##### <a name="-ipset--set--show_diff"></a>`show_diff`
+
+Data type: `Boolean`
+
+If ``true``, no diff content is being shown or logged.
+Useful for larget sets with lot of changes. Default: false
+
+Default value: `false`
+
 ##### <a name="-ipset--set--ignore_contents"></a>`ignore_contents`
 
 Data type: `Boolean`
@@ -239,15 +248,6 @@ If ``true``, Puppet will update the IP set in the kernel
 memory. If ``false``, it will only update the IP sets on the filesystem.
 
 Default value: `true`
-
-##### <a name="-ipset--set--show_diff"></a>`show_diff`
-
-Data type: `Boolean`
-
-show_diff If ``true``, no diff content is being shown or logged. 
-Useful for larget sets with lot of changes. Default: false
-
-Default value: `false`
 
 ### <a name="ipset--unmanaged"></a>`ipset::unmanaged`
 

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -115,48 +115,48 @@ define ipset::set (
         $new_set = join($set, "\n")
         # create file with ipset, one record per line
         file { "${config_path}/${title}.set":
-          ensure  => file,
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0640',
-          content => "${new_set}\n",
-          replace => !$ignore_contents,
+          ensure    => file,
+          owner     => 'root',
+          group     => 'root',
+          mode      => '0640',
+          content   => "${new_set}\n",
+          replace   => !$ignore_contents,
           show_diff => $show_diff,
         }
       }
       IPSet::Set::Puppet_URL: { # lint:ignore:unquoted_string_in_case
         # passed as puppet file
         file { "${config_path}/${title}.set":
-          ensure  => file,
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0640',
-          source  => $set,
-          replace => !$ignore_contents,
+          ensure    => file,
+          owner     => 'root',
+          group     => 'root',
+          mode      => '0640',
+          source    => $set,
+          replace   => !$ignore_contents,
           show_diff => $show_diff,
         }
       }
       IPSet::Set::File_URL: { # lint:ignore:unquoted_string_in_case
         # passed as target node file
         file { "${config_path}/${title}.set":
-          ensure  => file,
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0640',
-          source  => regsubst($set, '^.{7}', ''),
-          replace => !$ignore_contents,
+          ensure    => file,
+          owner     => 'root',
+          group     => 'root',
+          mode      => '0640',
+          source    => regsubst($set, '^.{7}', ''),
+          replace   => !$ignore_contents,
           show_diff => $show_diff,
         }
       }
       String: {
         # passed directly as content string (from template for example)
         file { "${config_path}/${title}.set":
-          ensure  => file,
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0640',
-          content => $set,
-          replace => !$ignore_contents,
+          ensure    => file,
+          owner     => 'root',
+          group     => 'root',
+          mode      => '0640',
+          content   => $set,
+          replace   => !$ignore_contents,
           show_diff => $show_diff,
         }
       }

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -4,6 +4,8 @@
 # @param ensure Should the IP set be created or removed ?
 # @param type Type of IP set.
 # @param options IP set options.
+# @param silent If ``true``, no diff content is being shown or logged. 
+#   Useful for larget sets with lot of changes. Default: false
 # @param ignore_contents If ``true``, only the IP set declaration will be
 #   managed, but not its content.
 # @param keep_in_sync If ``true``, Puppet will update the IP set in the kernel
@@ -69,6 +71,8 @@ define ipset::set (
   Enum['present', 'absent'] $ensure = 'present',
   IPSet::Type $type = 'hash:ip',
   IPSet::Options $options = {},
+  # Do not show/log diff output of changed file content
+  Boolean $silent = false,
   # do not touch what is inside the set, just its header (properties)
   Boolean $ignore_contents = false,
   # keep definition file and in-kernel runtime state in sync
@@ -117,6 +121,7 @@ define ipset::set (
           mode    => '0640',
           content => "${new_set}\n",
           replace => !$ignore_contents,
+          show_diff => $silent,
         }
       }
       IPSet::Set::Puppet_URL: { # lint:ignore:unquoted_string_in_case
@@ -128,6 +133,7 @@ define ipset::set (
           mode    => '0640',
           source  => $set,
           replace => !$ignore_contents,
+          show_diff => $silent,
         }
       }
       IPSet::Set::File_URL: { # lint:ignore:unquoted_string_in_case
@@ -139,6 +145,7 @@ define ipset::set (
           mode    => '0640',
           source  => regsubst($set, '^.{7}', ''),
           replace => !$ignore_contents,
+          show_diff => $silent,
         }
       }
       String: {
@@ -150,6 +157,7 @@ define ipset::set (
           mode    => '0640',
           content => $set,
           replace => !$ignore_contents,
+          show_diff => $silent,
         }
       }
       default: {

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -4,7 +4,7 @@
 # @param ensure Should the IP set be created or removed ?
 # @param type Type of IP set.
 # @param options IP set options.
-# @param silent If ``true``, no diff content is being shown or logged. 
+# @param show_diff If ``true``, no diff content is being shown or logged. 
 #   Useful for larget sets with lot of changes. Default: false
 # @param ignore_contents If ``true``, only the IP set declaration will be
 #   managed, but not its content.
@@ -121,7 +121,7 @@ define ipset::set (
           mode    => '0640',
           content => "${new_set}\n",
           replace => !$ignore_contents,
-          show_diff => $silent,
+          show_diff => $show_diff,
         }
       }
       IPSet::Set::Puppet_URL: { # lint:ignore:unquoted_string_in_case
@@ -133,7 +133,7 @@ define ipset::set (
           mode    => '0640',
           source  => $set,
           replace => !$ignore_contents,
-          show_diff => $silent,
+          show_diff => $show_diff,
         }
       }
       IPSet::Set::File_URL: { # lint:ignore:unquoted_string_in_case
@@ -145,7 +145,7 @@ define ipset::set (
           mode    => '0640',
           source  => regsubst($set, '^.{7}', ''),
           replace => !$ignore_contents,
-          show_diff => $silent,
+          show_diff => $show_diff,
         }
       }
       String: {
@@ -157,7 +157,7 @@ define ipset::set (
           mode    => '0640',
           content => $set,
           replace => !$ignore_contents,
-          show_diff => $silent,
+          show_diff => $show_diff,
         }
       }
       default: {

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -72,7 +72,7 @@ define ipset::set (
   IPSet::Type $type = 'hash:ip',
   IPSet::Options $options = {},
   # Do not show/log diff output of changed file content
-  Boolean $silent = false,
+  Boolean $show_diff= false,
   # do not touch what is inside the set, just its header (properties)
   Boolean $ignore_contents = false,
   # keep definition file and in-kernel runtime state in sync


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Added a **silent** flag to prevent screen/logging floods for ipsets which change often. The silent flag sets the show_diff parameter in the file resources. 

Also updated the reference file.

#### This Pull Request (PR) fixes the following issues
Fixes #136 
