### PR TITLE
Add atomic swap for ipset header

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ ipset::unmanaged { 'baz':
 Useful when you have a dynamic process that generates an IP set content,
 but still want to define and use it from Puppet.
 
-Warning: When changing IP set attributes (type, options) contents won't be kept, set will be recreated as empty.
+Warning: When changing IP set type, contents won't be kept, set will be recreated as empty.
+Changing other options (e.g. maxelem, hashsize) is handled via atomic swap, preserving contents even when the set is referenced by iptables rules.
 
 ## Reference
 

--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -198,11 +198,31 @@ if ipset_exists ${set_id}; then
       exit 3
     fi
 
-    # drop the old one
-    ipset destroy ${set_id}
+    # attempt atomic swap to update ipsets options seamlessly without
+    # disrupting iptables rules referencing this set.
+    # atomic swap is only possible when set types are compatible,
+    # if the set type changes, it falls back to destroy + recreate.
+    swap_alias="SWAP_${set_id}"
+    import_ipset ${set_id} ${swap_alias} ${ignore_contents}
+    result=$?
 
-    # create it with content as expected
-    import_ipset ${set_id} ${set_id} ${ignore_contents}
+    if [ ${result} -eq 0 ]; then
+      # try atomic swap (works when set types are compatible)
+      if ipset swap ${swap_alias} ${set_id}; then
+        # swap succeeded, destroy the old set (now under swap_alias)
+        ipset destroy ${swap_alias}
+        exit 0
+      else
+        # swap failed, clean up temp set
+        ipset destroy ${swap_alias}
+        # fall back to destroy + recreate
+        ipset destroy ${set_id}
+        import_ipset ${set_id} ${set_id} ${ignore_contents}
+      fi
+    else
+      # import of temp set failed, clean up
+      ipset destroy ${swap_alias} 2>/dev/null
+    fi
   else
     # hdr is the same
 

--- a/spec/acceptance/ipset_spec.rb
+++ b/spec/acceptance/ipset_spec.rb
@@ -56,4 +56,36 @@ describe 'ipset class' do
       its(:stdout) { is_expected.to match '' }
     end
   end
+
+  context 'ipsets headers atomic swap' do
+    it 'creates a set and references it in iptables' do
+      pp = <<-EOS
+      include ipset
+      ipset::set{'atomic-header-set':
+        set     => ['10.0.0.1', '10.0.0.2'],
+        type    => 'hash:net',
+        options => { 'maxelem' => 1000 },
+      }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      shell('iptables -A INPUT -m set --match-set atomic-header-set src -j ACCEPT')
+    end
+
+    it 'updates options while set is in use' do
+      pp = <<-EOS
+      include ipset
+      ipset::set{'atomic-header-set':
+        set     => ['10.0.0.1', '10.0.0.2'],
+        type    => 'hash:net',
+        options => { 'maxelem' => 1001 },
+      }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe command('ipset list atomic-header-set') do
+      its(:stdout) { is_expected.to match %r{maxelem 1001} }
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
When an ipset header changes (e.g. maxelem, hashsize), ipset_sync now attempts an atomic ipset swap before falling back to destroy + recreate. This allows seamless option updates even when the set is referenced by iptables rules.

*What changed*

- When a header difference is detected, create a temporary set **SWAP_name** with the updated header and content, then attempt ipset swap to replace the active set atomically.
- If the swap succeeds (same set type), the old set is destroyed. No disruption to iptables.
- If the swap fails (incompatible set types), fall back to destroy + recreate. This will fail if the set is referenced by iptables, this is expected and unavoidable when changing set types.

*Limitations*
Atomic swap only works when the set type remains the same. Changing the set type (e.g. hash:ip -> hash:net) requires destroy + recreate, which will fail if the set is in use by iptables.


#### This Pull Request (PR) fixes the following issues
Fixes #141 
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
